### PR TITLE
Move codeception requirement to suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
             "bscheshirwork\\Codeception\\Module\\": "\\"
         }
     },
-    "require": {
-        "codeception/codeception": "*"
+    "suggest": {
+        "codeception/codeception": "Codeception framework"
     }
 }


### PR DESCRIPTION
Codeception may also be installed with https://github.com/codeception/base/ so we should remove the explicit require and simply suggest it.